### PR TITLE
ISO documents - minor corrections

### DIFF
--- a/sources/international-standard/body/body-en.adoc
+++ b/sources/international-standard/body/body-en.adoc
@@ -49,7 +49,7 @@ The holder of this patent right has assured ISO that he/she is willing to negoti
 Vache Equipment +
 Fictitious +
 World +
-gehf@vacheequipment.fic
+mailto:gehf@vacheequipment.fic
 
 Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights other than those identified above. ISO shall not be held responsible for identifying any or all such patent rights.
 

--- a/sources/international-standard/body/body-en.adoc
+++ b/sources/international-standard/body/body-en.adoc
@@ -256,7 +256,7 @@ NOTE: Only full red husked (cargo) rice is considered in this table.
 
 [[clause5]]
 == Sampling
-Sampling shall be carried out in accordance with <<ISO24333,clause 5>>
+Sampling shall be carried out in accordance with <<ISO24333,ISO 24333:2009, Clause 5>>.
 
 == Test methods
 

--- a/sources/international-standard/body/body-zh.adoc
+++ b/sources/international-standard/body/body-zh.adoc
@@ -54,7 +54,7 @@ ISO / IEC指令第1部分描述了用于开发此文件的程序和用于进一�
 Vache Equipment +
 Fictitious +
 World +
-gehf@vacheequipment.fic
+mailto:gehf@vacheequipment.fic
 
 请注意本文件的某些内容可能成为上述以外专利权的主题。 发行人不负责识别任何或所有此类专利权。
 

--- a/sources/international-standard/sections-en/00-introduction.adoc
+++ b/sources/international-standard/sections-en/00-introduction.adoc
@@ -17,7 +17,7 @@ The holder of this patent right has assured ISO that he/she is willing to negoti
 Vache Equipment +
 Fictitious +
 World +
-gehf@vacheequipment.fic
+mailto:gehf@vacheequipment.fic
 
 Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights other than those identified above. ISO shall not be held responsible for identifying any or all such patent rights.
 

--- a/sources/international-standard/sections-en/05-sampling.adoc
+++ b/sources/international-standard/sections-en/05-sampling.adoc
@@ -1,4 +1,4 @@
 [[clause5]]
 == Sampling
 
-Sampling shall be carried out in accordance with <<ISO24333,clause 5>>
+Sampling shall be carried out in accordance with <<ISO24333,ISO 24333:2009, Clause 5>>.

--- a/sources/international-standard/sections-zh/00-introduction.adoc
+++ b/sources/international-standard/sections-zh/00-introduction.adoc
@@ -16,7 +16,7 @@ The holder of this patent right has assured ISO that he/she is willing to negoti
 Vache Equipment +
 Fictitious +
 World +
-gehf@vacheequipment.fic
+mailto:gehf@vacheequipment.fic
 
 Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights other than those identified above. ISO shall not be held responsible for identifying any or all such patent rights.
 


### PR DESCRIPTION
- Added `mailto:` in accordance to https://github.com/metanorma/iso-10303/pull/48#issuecomment-628110994.
- Minor markup corrections.