### PR TITLE
Clean up site commands

### DIFF
--- a/.github/workflows/docker-pres_xml.yml
+++ b/.github/workflows/docker-pres_xml.yml
@@ -18,10 +18,10 @@ jobs:
 
       - run: curl -L --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/gemfile-to-bundle-add.sh | bash
 
-      - run: metanorma site generate . -o published -c metanorma.yml --agree-to-terms
+      - run: metanorma site generate --agree-to-terms
 
       - uses: actions/upload-artifact@master
         if: github.ref == 'refs/heads/master'
         with:
-          name: published
-          path: published
+          name: site
+          path: site

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,12 +34,12 @@ jobs:
 
       - run: curl -L --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/gemfile-to-bundle-add.sh | bash
 
-      - run: metanorma site generate . -o published -c metanorma.yml --agree-to-terms
+      - run: metanorma site generate --agree-to-terms
 
       - uses: actions/upload-artifact@master
         with:
-          name: published
-          path: published
+          name: site
+          path: site
 
   deploy-gh-pages:
     if: github.ref == 'refs/heads/master'
@@ -50,12 +50,12 @@ jobs:
 
       - uses: actions/download-artifact@v1
         with:
-          name: published
+          name: site
 
       - uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.GH_DEPLOY_KEY }}
-          publish_dir: ./published
+          publish_dir: ./site
           force_orphan: true
           user_name: ${{ github.actor }}
           user_email: ${{ format('{0}@users.noreply.github.com', github.actor) }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -41,4 +41,4 @@ jobs:
 
       - uses: actions-mn/setup@master
 
-      - run: metanorma site generate . -o published -c metanorma.yml --agree-to-terms
+      - run: metanorma site generate --agree-to-terms

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,4 +62,4 @@ jobs:
           os.system("gem install specific_install")
           os.system("gem specific_install -l https://github.com/{}.git -b {}".format(repo, branch))
 
-      - run: metanorma site generate . -o published -c metanorma.yml --agree-to-terms
+      - run: metanorma site generate --agree-to-terms

--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ If you don't want to deal with local dependencies, use the docker:
 
 [source,sh]
 ----
-docker run -v "$(pwd)":/metanorma -w /metanorma -it metanorma/mn metanorma site generate . -o published -c metanorma.yml
+docker run -v "$(pwd)":/metanorma -w /metanorma -it metanorma/mn metanorma site generate
 ----
 
 
@@ -46,7 +46,7 @@ docker run -v "$(pwd)":/metanorma -w /metanorma -it metanorma/mn metanorma site 
 
 [source,sh]
 ----
-metanorma site generate . -o published -c metanorma.yml
+metanorma site generate
 ----
 
 

--- a/sources/amendment/rice-amd-fr.adoc
+++ b/sources/amendment/rice-amd-fr.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd-fr.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.awi.adoc
+++ b/sources/amendment/rice-amd.awi.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.cd.adoc
+++ b/sources/amendment/rice-amd.cd.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.damd.adoc
+++ b/sources/amendment/rice-amd.damd.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.fdamd.adoc
+++ b/sources/amendment/rice-amd.fdamd.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.final.adoc
+++ b/sources/amendment/rice-amd.final.adoc
@@ -33,7 +33,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.np.adoc
+++ b/sources/amendment/rice-amd.np.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.prf.adoc
+++ b/sources/amendment/rice-amd.prf.adoc
@@ -33,7 +33,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/amendment/rice-amd.wd.adoc
+++ b/sources/amendment/rice-amd.wd.adoc
@@ -32,7 +32,6 @@
 :secretariat:
 :language: en
 :imagesdir: images
-:docfile: rice-amd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/directives/part1/document.adoc
+++ b/sources/directives/part1/document.adoc
@@ -23,7 +23,6 @@
 :workgroup-type: WG
 :workgroup-number:
 :workgroup:
-:docfile: document.adoc
 :imagesdir: images
 :library-ics:
 :mn-document-class: iso

--- a/sources/directives/part2/document.adoc
+++ b/sources/directives/part2/document.adoc
@@ -21,7 +21,6 @@
 :workgroup-type: WG
 :workgroup-number:
 :workgroup:
-:docfile: document.adoc
 :imagesdir: images
 :library-ics:
 :mn-document-class: iso

--- a/sources/international-standard/rice-en.awi.adoc
+++ b/sources/international-standard/rice-en.awi.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.awi.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.cd.adoc
+++ b/sources/international-standard/rice-en.cd.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.cd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.cd.sections.adoc
+++ b/sources/international-standard/rice-en.cd.sections.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.cd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.dis.adoc
+++ b/sources/international-standard/rice-en.dis.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.dis.adoc
 :library-ics: 67.060
 :vote-started-date: 2020-02-19
 :vote-ended-date: 2020-05-13

--- a/sources/international-standard/rice-en.fdis.adoc
+++ b/sources/international-standard/rice-en.fdis.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.fdis.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.final.adoc
+++ b/sources/international-standard/rice-en.final.adoc
@@ -23,7 +23,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.final.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.np.adoc
+++ b/sources/international-standard/rice-en.np.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.nwip.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.prf.adoc
+++ b/sources/international-standard/rice-en.prf.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.prf.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-en.wd.adoc
+++ b/sources/international-standard/rice-en.wd.adoc
@@ -24,7 +24,6 @@
 :workgroup-type: WG
 :workgroup-number: 4
 :workgroup: Amylose in rice
-:docfile: rice-en.covers.wd.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-fr.adoc
+++ b/sources/international-standard/rice-fr.adoc
@@ -37,7 +37,6 @@
 :example-refsig: Exemple
 :caution-caption: Attention
 :warning-caption: Avertissement
-:docfile: rice-fr.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-standard/rice-zh.adoc
+++ b/sources/international-standard/rice-zh.adoc
@@ -33,7 +33,6 @@
 :section-refsig: 章
 :table-caption: 表
 :example-caption: 例
-:docfile: rice-zh.adoc
 :library-ics: 67.060
 :mn-document-class: iso
 :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl

--- a/sources/international-workshop-agreement/document.adoc
+++ b/sources/international-workshop-agreement/document.adoc
@@ -61,7 +61,6 @@
 :comment: ### Directory in which images are located: all local image file locations are prefixed with this directory. (Optional.)
 :imagesdir: images
 :comment: ### Name of this AsciiDoc file
-:docfile: document.adoc
 :comment: ### Metanorma flavour: applies to all ISO documents
 :mn-document-class: iso
 :comment: ### Desired output formats. Metanorma-ISO supports the following output extension values: xml (MN XML), html (ISO-style HTML), html_alt (pretty HTML), doc (Word .doc)

--- a/sources/publicly-available-specification/document.adoc
+++ b/sources/publicly-available-specification/document.adoc
@@ -61,7 +61,6 @@
 :comment: ### Directory in which images are located: all local image file locations are prefixed with this directory. (Optional.)
 :imagesdir: images
 :comment: ### Name of this AsciiDoc file
-:docfile: document.adoc
 :comment: ### Metanorma flavour: applies to all ISO documents
 :mn-document-class: iso
 :comment: ### Desired output formats. Metanorma-ISO supports the following output extension values: xml (MN XML), html (ISO-style HTML), html_alt (pretty HTML), doc (Word .doc)

--- a/sources/technical-report/document.adoc
+++ b/sources/technical-report/document.adoc
@@ -56,7 +56,6 @@
 :comment: ### Directory in which images are located: all local image file locations are prefixed with this directory. (Optional.)
 :imagesdir: images
 :comment: ### Name of this AsciiDoc file
-:docfile: document.adoc
 :comment: ### Metanorma flavour: applies to all ISO documents
 :mn-document-class: iso
 :comment: ### Desired output formats. Metanorma-ISO supports the following output extension values: xml (MN XML), html (ISO-style HTML), html_alt (pretty HTML), doc (Word .doc)

--- a/sources/technical-specification/document.adoc
+++ b/sources/technical-specification/document.adoc
@@ -62,7 +62,6 @@
 :comment: ### Directory in which images are located: all local image file locations are prefixed with this directory. (Optional.)
 :imagesdir: images
 :comment: ### Name of this AsciiDoc file
-:docfile: document.adoc
 :comment: ### Metanorma flavour: applies to all ISO documents
 :mn-document-class: iso
 :comment: ### Desired output formats. Metanorma-ISO supports the following output extension values: xml (MN XML), html (ISO-style HTML), html_alt (pretty HTML), doc (Word .doc)


### PR DESCRIPTION
Somehow this is crashing. I think this is to do with the updated integration between Metanorma and Fontist.