### PR TITLE
metanorma/metanorma-build-scripts#66 Drop ruby 2.4 support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,10 +9,7 @@ on:
     paths-ignore:
       - .gitlab-ci.yml
       - .github/workflows/test.yml
-      - .github/workflows/macos.yml
-      - .github/workflows/ubuntu.yml
-      - .github/workflows/windows.yml
-      - .github/workflows/docker-pres_xml.yml
+      - .github/workflows/generate.yml
   repository_dispatch:
     types: [ metanorma/metanorma-docker ]
 
@@ -31,6 +28,12 @@ jobs:
           path: /config/fonts
           key: fontist-docker
           restore-keys: fontist-docker
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.metanorma-ietf-workgroup-cache.json
+          key: metanorma-ietf-workgroup-cache
+          restore-keys: metanorma-ietf-workgroup-cache
 
       - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
         with:
@@ -61,7 +64,7 @@ jobs:
 
       - uses: peaceiris/actions-gh-pages@v3
         with:
-          deploy_key: ${{ secrets.GH_DEPLOY_KEY }}
+          github_token: ${{ github.token }}
           publish_dir: ./site
           force_orphan: true
           user_name: ${{ github.actor }}
@@ -70,5 +73,5 @@ jobs:
 
       - uses: kolpav/purge-artifacts-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           expire-in: 0

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -10,7 +10,6 @@ on:
       - .gitlab-ci.yml
       - .github/workflows/test.yml
       - .github/workflows/docker.yml
-      - .github/workflows/docker-pres_xml.yml
   workflow_dispatch:
 
 jobs:
@@ -38,6 +37,15 @@ jobs:
           path: ~/.fontist
           key: fontist-${{ runner.os }}
           restore-keys: fontist-${{ runner.os }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.metanorma-ietf-workgroup-cache.json
+          key: metanorma-ietf-workgroup-cache
+          restore-keys: metanorma-ietf-workgroup-cache
+
+      - if: matrix.os == 'windows-latest'
+        run: rm Gemfile
 
       - uses: actions-mn/setup@master
 


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.